### PR TITLE
Update colors for rubric and assessment scores

### DIFF
--- a/dist/forum-design-system.css
+++ b/dist/forum-design-system.css
@@ -63,7 +63,13 @@
   --hc-2: #F0871E;
   --hc-3: #33AB6F;
   --hc-4: #0A78BF;
-  --hc-5: #5B3E97; }
+  --hc-5: #5B3E97;
+  --hc-light-0: #e6e6e6;
+  --hc-light-1: #fceae9;
+  --hc-light-2: #fef3e9;
+  --hc-light-3: #ebf7f1;
+  --hc-light-4: #e7f2f9;
+  --hc-light-5: #efecf5; }
 
 .bg-blue {
   background-color: #0A78BF; }
@@ -259,6 +265,24 @@
 
 .bg-hc-5 {
   background-color: #5B3E97; }
+
+.bg-hc-light-0 {
+  background-color: #e6e6e6; }
+
+.bg-hc-light-1 {
+  background-color: #fceae9; }
+
+.bg-hc-light-2 {
+  background-color: #fef3e9; }
+
+.bg-hc-light-3 {
+  background-color: #ebf7f1; }
+
+.bg-hc-light-4 {
+  background-color: #e7f2f9; }
+
+.bg-hc-light-5 {
+  background-color: #efecf5; }
 
 .text-black {
   color: var(--black); }
@@ -529,6 +553,24 @@
 
 .outline-2-hc-5 {
   box-shadow: 0 0 0 2px #5B3E97; }
+
+.outline-2-hc-light-0 {
+  box-shadow: 0 0 0 2px #e6e6e6; }
+
+.outline-2-hc-light-1 {
+  box-shadow: 0 0 0 2px #fceae9; }
+
+.outline-2-hc-light-2 {
+  box-shadow: 0 0 0 2px #fef3e9; }
+
+.outline-2-hc-light-3 {
+  box-shadow: 0 0 0 2px #ebf7f1; }
+
+.outline-2-hc-light-4 {
+  box-shadow: 0 0 0 2px #e7f2f9; }
+
+.outline-2-hc-light-5 {
+  box-shadow: 0 0 0 2px #efecf5; }
 
 .shadow-level-1 {
   box-shadow: 0px 1px 3px 0px rgba(1, 1, 1, 0.12); }

--- a/dist/forum-design-system.css
+++ b/dist/forum-design-system.css
@@ -58,7 +58,7 @@
   --black-tint-90: #e6e6e6;
   --black-tint-95: #f2f2f2;
   --black-tint-97: #f7f7f7;
-  --hc-0: #e6e6e6;
+  --hc-0: #676767;
   --hc-1: #DF2F26;
   --hc-2: #F0871E;
   --hc-3: #33AB6F;
@@ -243,7 +243,7 @@
   background-color: #f7f7f7; }
 
 .bg-hc-0 {
-  background-color: #e6e6e6; }
+  background-color: #676767; }
 
 .bg-hc-1 {
   background-color: #DF2F26; }
@@ -513,7 +513,7 @@
   box-shadow: 0 0 0 2px #f7f7f7; }
 
 .outline-2-hc-0 {
-  box-shadow: 0 0 0 2px #e6e6e6; }
+  box-shadow: 0 0 0 2px #676767; }
 
 .outline-2-hc-1 {
   box-shadow: 0 0 0 2px #DF2F26; }

--- a/dist/forum-design-system.css
+++ b/dist/forum-design-system.css
@@ -58,18 +58,18 @@
   --black-tint-90: #e6e6e6;
   --black-tint-95: #f2f2f2;
   --black-tint-97: #f7f7f7;
-  --hc-0: #676767;
-  --hc-1: #DF2F26;
-  --hc-2: #F0871E;
-  --hc-3: #33AB6F;
-  --hc-4: #0A78BF;
-  --hc-5: #5B3E97;
-  --hc-light-0: #e6e6e6;
-  --hc-light-1: #fceae9;
-  --hc-light-2: #fef3e9;
-  --hc-light-3: #ebf7f1;
-  --hc-light-4: #e7f2f9;
-  --hc-light-5: #efecf5; }
+  --score-0: #676767;
+  --score-1: #DF2F26;
+  --score-2: #F0871E;
+  --score-3: #33AB6F;
+  --score-4: #0A78BF;
+  --score-5: #5B3E97;
+  --score-light-0: #e6e6e6;
+  --score-light-1: #fceae9;
+  --score-light-2: #fef3e9;
+  --score-light-3: #ebf7f1;
+  --score-light-4: #e7f2f9;
+  --score-light-5: #efecf5; }
 
 .bg-blue {
   background-color: #0A78BF; }
@@ -248,40 +248,40 @@
 .bg-black-tint-97 {
   background-color: #f7f7f7; }
 
-.bg-hc-0 {
+.bg-score-0 {
   background-color: #676767; }
 
-.bg-hc-1 {
+.bg-score-1 {
   background-color: #DF2F26; }
 
-.bg-hc-2 {
+.bg-score-2 {
   background-color: #F0871E; }
 
-.bg-hc-3 {
+.bg-score-3 {
   background-color: #33AB6F; }
 
-.bg-hc-4 {
+.bg-score-4 {
   background-color: #0A78BF; }
 
-.bg-hc-5 {
+.bg-score-5 {
   background-color: #5B3E97; }
 
-.bg-hc-light-0 {
+.bg-score-light-0 {
   background-color: #e6e6e6; }
 
-.bg-hc-light-1 {
+.bg-score-light-1 {
   background-color: #fceae9; }
 
-.bg-hc-light-2 {
+.bg-score-light-2 {
   background-color: #fef3e9; }
 
-.bg-hc-light-3 {
+.bg-score-light-3 {
   background-color: #ebf7f1; }
 
-.bg-hc-light-4 {
+.bg-score-light-4 {
   background-color: #e7f2f9; }
 
-.bg-hc-light-5 {
+.bg-score-light-5 {
   background-color: #efecf5; }
 
 .text-black {
@@ -341,23 +341,23 @@
 .text-blue-violet {
   color: #322864; }
 
-.text-hc-0 {
-  color: var(--hc-0) !important; }
+.text-score-0 {
+  color: var(--score-0) !important; }
 
-.text-hc-1 {
-  color: var(--hc-1) !important; }
+.text-score-1 {
+  color: var(--score-1) !important; }
 
-.text-hc-2 {
-  color: var(--hc-2) !important; }
+.text-score-2 {
+  color: var(--score-2) !important; }
 
-.text-hc-3 {
-  color: var(--hc-3) !important; }
+.text-score-3 {
+  color: var(--score-3) !important; }
 
-.text-hc-4 {
-  color: var(--hc-4) !important; }
+.text-score-4 {
+  color: var(--score-4) !important; }
 
-.text-hc-5 {
-  color: var(--hc-5) !important; }
+.text-score-5 {
+  color: var(--score-5) !important; }
 
 .outline-2-blue {
   box-shadow: 0 0 0 2px #0A78BF; }
@@ -536,40 +536,40 @@
 .outline-2-black-tint-97 {
   box-shadow: 0 0 0 2px #f7f7f7; }
 
-.outline-2-hc-0 {
+.outline-2-score-0 {
   box-shadow: 0 0 0 2px #676767; }
 
-.outline-2-hc-1 {
+.outline-2-score-1 {
   box-shadow: 0 0 0 2px #DF2F26; }
 
-.outline-2-hc-2 {
+.outline-2-score-2 {
   box-shadow: 0 0 0 2px #F0871E; }
 
-.outline-2-hc-3 {
+.outline-2-score-3 {
   box-shadow: 0 0 0 2px #33AB6F; }
 
-.outline-2-hc-4 {
+.outline-2-score-4 {
   box-shadow: 0 0 0 2px #0A78BF; }
 
-.outline-2-hc-5 {
+.outline-2-score-5 {
   box-shadow: 0 0 0 2px #5B3E97; }
 
-.outline-2-hc-light-0 {
+.outline-2-score-light-0 {
   box-shadow: 0 0 0 2px #e6e6e6; }
 
-.outline-2-hc-light-1 {
+.outline-2-score-light-1 {
   box-shadow: 0 0 0 2px #fceae9; }
 
-.outline-2-hc-light-2 {
+.outline-2-score-light-2 {
   box-shadow: 0 0 0 2px #fef3e9; }
 
-.outline-2-hc-light-3 {
+.outline-2-score-light-3 {
   box-shadow: 0 0 0 2px #ebf7f1; }
 
-.outline-2-hc-light-4 {
+.outline-2-score-light-4 {
   box-shadow: 0 0 0 2px #e7f2f9; }
 
-.outline-2-hc-light-5 {
+.outline-2-score-light-5 {
   box-shadow: 0 0 0 2px #efecf5; }
 
 .shadow-level-1 {

--- a/index.html
+++ b/index.html
@@ -200,19 +200,6 @@
   </div>
 </div>
 
-<h3 class="h3 mt6 mb4">HC Colors</h3>
-
-<p>There are aliases for HC colors:</p>
-
-<div>
-  <div class="swatch bg-hc-0 text-black">bg-hc-0</div>
-  <div class="swatch bg-hc-1 text-white">bg-hc-1</div>
-  <div class="swatch bg-hc-2 text-black">bg-hc-2</div>
-  <div class="swatch bg-hc-3 text-black">bg-hc-3</div>
-  <div class="swatch bg-hc-4 text-white">bg-hc-4</div>
-  <div class="swatch bg-hc-5 text-white">bg-hc-5</div>
-</div>
-
 <h3 class="h3 mt6 mb4">Text Colors</h3>
 
 <p>Use these classes to set text color:</p>
@@ -239,15 +226,43 @@
   <div class="swatch bg-white text-blue-violet">text-blue-violet</div>
 </div>
 
-<p>There are aliases for HC colors:</p>
+<h3 class="h3 mt6 mb4">Rubric / Assessment Score Colors</h3>
 
-<div>
-  <div class="swatch bg-black text-hc-0">text-hc-0</div>
-  <div class="swatch bg-white text-hc-1">text-hc-1</div>
-  <div class="swatch bg-white text-hc-2">text-hc-2</div>
-  <div class="swatch bg-white text-hc-3">text-hc-3</div>
-  <div class="swatch bg-white text-hc-4">text-hc-4</div>
-  <div class="swatch bg-white text-hc-5">text-hc-5</div>
+<p>
+  There are aliases for colors used in the display of rubric and assessment scores.
+  They come in dark and light shades for backgrounds, and in dark shades for text
+  colors. The number at the end corresponds to the score value being rendered, in
+  the range 0 - 5. You can also refer to the colors directly in CSS expressions,
+  e.g.,<code>var(--score-0)</code> or <code>var(--score-light-5)</code>.
+</p>
+
+<div class="flex mb4">
+  <div class="mr4">
+    <div class="swatch bg-score-0 text-white">bg-score-0</div>
+    <div class="swatch bg-score-1 text-white">bg-score-1</div>
+    <div class="swatch bg-score-2 text-white">bg-score-2</div>
+    <div class="swatch bg-score-3 text-white">bg-score-3</div>
+    <div class="swatch bg-score-4 text-white">bg-score-4</div>
+    <div class="swatch bg-score-5 text-white">bg-score-5</div>
+  </div>
+
+  <div>
+    <div class="swatch bg-score-light-0 text-black">bg-score-light-0</div>
+    <div class="swatch bg-score-light-1 text-black">bg-score-light-1</div>
+    <div class="swatch bg-score-light-2 text-black">bg-score-light-2</div>
+    <div class="swatch bg-score-light-3 text-black">bg-score-light-3</div>
+    <div class="swatch bg-score-light-4 text-black">bg-score-light-4</div>
+    <div class="swatch bg-score-light-5 text-black">bg-score-light-5</div>
+  </div>
+
+  <div>
+    <div class="swatch bg-white text-score-0">text-score-0</div>
+    <div class="swatch bg-white text-score-1">text-score-1</div>
+    <div class="swatch bg-white text-score-2">text-score-2</div>
+    <div class="swatch bg-white text-score-3">text-score-3</div>
+    <div class="swatch bg-white text-score-4">text-score-4</div>
+    <div class="swatch bg-white text-score-5">text-score-5</div>
+  </div>
 </div>
 
 <h2 class="h2 mt10 mb4" id="status">Status</h2>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forum-design-system",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "",
   "style": "src/index.css",
   "main": "src/index.css",

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -57,6 +57,12 @@ $all-colors: map-merge($all-colors, (
         "hc-3": map-get($all-colors, "green"),
         "hc-4": map-get($all-colors, "blue"),
         "hc-5": map-get($all-colors, "violet"),
+        "hc-light-0": map-get($all-colors, "black-tint-90"),
+        "hc-light-1": map-get($all-colors, "red-tint-90"),
+        "hc-light-2": map-get($all-colors, "orange-tint-90"),
+        "hc-light-3": map-get($all-colors, "green-tint-90"),
+        "hc-light-4": map-get($all-colors, "blue-tint-90"),
+        "hc-light-5": map-get($all-colors, "violet-tint-90"),
 ));
 
 // Copy all Sass variables to CSS variables

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -49,20 +49,20 @@ $all-colors: map-merge($all-colors, (
   ));
 }
 
-// Add aliases for HC colors
+// Add aliases for rubric / assessment score colors
 $all-colors: map-merge($all-colors, (
-        "hc-0": map-get($all-colors, "black-tint-40"),
-        "hc-1": map-get($all-colors, "red"),
-        "hc-2": map-get($all-colors, "orange"),
-        "hc-3": map-get($all-colors, "green"),
-        "hc-4": map-get($all-colors, "blue"),
-        "hc-5": map-get($all-colors, "violet"),
-        "hc-light-0": map-get($all-colors, "black-tint-90"),
-        "hc-light-1": map-get($all-colors, "red-tint-90"),
-        "hc-light-2": map-get($all-colors, "orange-tint-90"),
-        "hc-light-3": map-get($all-colors, "green-tint-90"),
-        "hc-light-4": map-get($all-colors, "blue-tint-90"),
-        "hc-light-5": map-get($all-colors, "violet-tint-90"),
+        "score-0": map-get($all-colors, "black-tint-40"),
+        "score-1": map-get($all-colors, "red"),
+        "score-2": map-get($all-colors, "orange"),
+        "score-3": map-get($all-colors, "green"),
+        "score-4": map-get($all-colors, "blue"),
+        "score-5": map-get($all-colors, "violet"),
+        "score-light-0": map-get($all-colors, "black-tint-90"),
+        "score-light-1": map-get($all-colors, "red-tint-90"),
+        "score-light-2": map-get($all-colors, "orange-tint-90"),
+        "score-light-3": map-get($all-colors, "green-tint-90"),
+        "score-light-4": map-get($all-colors, "blue-tint-90"),
+        "score-light-5": map-get($all-colors, "violet-tint-90"),
 ));
 
 // Copy all Sass variables to CSS variables
@@ -123,26 +123,26 @@ $all-colors: map-merge($all-colors, (
   }
 }
 
-.text-hc-0 {
-  color: var(--hc-0) !important;
+.text-score-0 {
+  color: var(--score-0) !important;
 }
 
-.text-hc-1 {
-  color: var(--hc-1) !important;
+.text-score-1 {
+  color: var(--score-1) !important;
 }
 
-.text-hc-2 {
-  color: var(--hc-2) !important;
+.text-score-2 {
+  color: var(--score-2) !important;
 }
 
-.text-hc-3 {
-  color: var(--hc-3) !important;
+.text-score-3 {
+  color: var(--score-3) !important;
 }
 
-.text-hc-4 {
-  color: var(--hc-4) !important;
+.text-score-4 {
+  color: var(--score-4) !important;
 }
 
-.text-hc-5 {
-  color: var(--hc-5) !important;
+.text-score-5 {
+  color: var(--score-5) !important;
 }

--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -51,7 +51,7 @@ $all-colors: map-merge($all-colors, (
 
 // Add aliases for HC colors
 $all-colors: map-merge($all-colors, (
-        "hc-0": map-get($all-colors, "black-tint-90"),
+        "hc-0": map-get($all-colors, "black-tint-40"),
         "hc-1": map-get($all-colors, "red"),
         "hc-2": map-get($all-colors, "orange"),
         "hc-3": map-get($all-colors, "green"),


### PR DESCRIPTION
## Description for reviewers

#### Motivation for this PR

Summary:
* Replace all mentions of "hc" with "score" in color names and CSS class names.
* Make the `score-0` alias refer to `black-tint-40` (dark gray) instead of `black-tint-90` (light gray)
* Add a set of aliases for lighter shades of score colors, e.g. `score-light-0`.

Required for https://github.com/minervaproject/picasso/pull/11027.

#### Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactor
- [ ] Other

#### Related Asana task

N/A

#### Virtual "desk check"

N/A

## Risk and security assessment

#### Testing

##### Automated tests

- [x] Modified code is covered by automated tests
- [ ] Modified code is partly covered by automated tests
- [ ] Modified code is not covered by automated tests at all

##### Other tests

- [X] Modified code was tested locally
- [ ] A bug bash was conducted. If so, please link to a document with explicitly listed test cases
- For functionality uncovered by tests, how was it verified?

#### Deployment risk

How risky is this PR to deploy?
- N/A

#### Roll out

- [ ] Feature flag
- [ ] 3-step migration
- [x] All at once

#### Security and performance

- [ ] Changes in this PR might dramatically impact performance
- [x] Security impact of change has been considered. See [this page](https://owasp.org/www-project-top-ten/) for common web applications security risks. In particular, "Sensitive Data Exposure" and "Broken Access Control" are frequently relevant to application changes.
- [x] Code follows [company security practices and guidelines](https://docs.google.com/document/d/1XxDzlVGWBwIv7FD54tkuSPufhtDAM3NWwSto0rzUsco/edit?usp=sharing)
